### PR TITLE
use absolute path for slicer executable

### DIFF
--- a/slicer.cabal
+++ b/slicer.cabal
@@ -42,6 +42,7 @@ test-suite slicer-test-suite
   default-language: Haskell2010
   main-is:          SlicerTestSuite.hs
   build-depends:    base         >= 4.8 && < 4.10,
+                    directory    >= 1.2.6.2,
                     filepath     >= 1.4,
                     process      >= 1.4,
                     tasty        >= 0.11,

--- a/tests/SlicerTestSuiteUtils.hs
+++ b/tests/SlicerTestSuiteUtils.hs
@@ -1,6 +1,7 @@
 module SlicerTestSuiteUtils where
 
 import           System.FilePath   ( joinPath                            )
+import           System.Directory  ( makeAbsolute                        )
 import           System.IO         ( IOMode(..), openFile                )
 import           System.Process    ( CreateProcess(..), StdStream(..)
                                    , createProcess, proc, waitForProcess )
@@ -17,8 +18,7 @@ tmlFilesPath = [ "examples" ]
 
 -- path to slicer executable relative to goldenPath
 slicerPath :: FilePath
-slicerPath = joinPath $ replicate (length goldenPath) ".." ++
-                                  [ "dist", "build", "slicer", "slicer" ]
+slicerPath = joinPath $ [ "dist", "build", "slicer", "slicer" ]
 
 -- location of tests
 relativeTestPath :: [FilePath]
@@ -42,7 +42,8 @@ runTMLTest testName =
       runTMLFile :: IO ()
       runTMLFile = do
         hActualFile <- openFile actualFilePath WriteMode
-        (_, _, _, pid) <- createProcess (proc slicerPath [testFile])
+        absSlicerPath <- makeAbsolute (slicerPath)
+        (_, _, _, pid) <- createProcess (proc absSlicerPath [testFile])
                                         { std_out = UseHandle hActualFile
                                         , std_err = UseHandle hActualFile
                                         , cwd     = Just (joinPath goldenPath) }


### PR DESCRIPTION
Avoids an inconsistency among OSs regarding how createProcess works:

https://github.com/haskell/process/issues/87

