### PR TITLE
Add support for exceptions in TML programs

### DIFF
--- a/bench/SlicerBenchmarkSuite.hs
+++ b/bench/SlicerBenchmarkSuite.hs
@@ -41,6 +41,7 @@ benchmarkFiles = map (\file -> "examples" ++ [pathSeparator] ++ file ++ ".tml")
     , "curried-pointwise-sum"
     , "curried-pointwise-sum-two"
     , "example"
+    , "exceptions"
     , "filter"
     , "foo"
     , "map-increment-closed"

--- a/examples/exceptions.tml
+++ b/examples/exceptions.tml
@@ -1,4 +1,4 @@
 let n = ref 0 in
 try
-  n:=17;;(raise (raise n));;n:=42;;(!n)
-with (x : ref int) => !x
+  n:=17;;(raise (raise "foo"));;n:=42;;(!n)
+with x => !n

--- a/examples/exceptions.tml
+++ b/examples/exceptions.tml
@@ -1,0 +1,4 @@
+let n = ref 0 in
+try
+  n:=17;;(raise (raise n));;n:=42;;(!n)
+with (x : ref int) => !x

--- a/lib/Language/Slicer/Absyn.hs
+++ b/lib/Language/Slicer/Absyn.hs
@@ -96,7 +96,7 @@ data Exp = Var Var | Let Var Exp Exp | LetR Var Exp
          -- References
          | Ref Exp  | Deref Exp | Assign Exp Exp | Seq Exp Exp
          -- Exceptions
-         | Raise Exp | Catch Exp Var Type Exp
+         | Raise Exp | Catch Exp Var Exp
          -- run-time tracing
          | Trace Exp
          -- holes

--- a/lib/Language/Slicer/Absyn.hs
+++ b/lib/Language/Slicer/Absyn.hs
@@ -1,6 +1,7 @@
-{-# LANGUAGE DeriveAnyClass   #-}
-{-# LANGUAGE DeriveGeneric    #-}
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE NamedFieldPuns     #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Language.Slicer.Absyn
     ( -- * Abstract syntax
@@ -94,6 +95,8 @@ data Exp = Var Var | Let Var Exp Exp | LetR Var Exp
          | Fun Code | App Exp Exp
          -- References
          | Ref Exp  | Deref Exp | Assign Exp Exp | Seq Exp Exp
+         -- Exceptions
+         | Raise Exp | Catch Exp Var Type Exp
          -- run-time tracing
          | Trace Exp
          -- holes
@@ -105,8 +108,28 @@ data Type = IntTy | BoolTy | UnitTy | StringTy
           | TyVar TyVar
           -- References
           | RefTy Type
+          -- Exception type
+          | ExnTy
           -- Trace types
           | TraceTy Type
-            deriving (Show, Eq, Ord, Generic, NFData)
+            deriving (Show, Generic, NFData)
+
+-- We need a hand-written instance of Eq, because ExnTy is equal to every type
+instance Eq Type where
+    ExnTy        == _              = True
+    _            == ExnTy          = True
+    IntTy        == IntTy          = True
+    BoolTy       == BoolTy         = True
+    UnitTy       == UnitTy         = True
+    StringTy     == StringTy       = True
+    PairTy t1 t2 == PairTy t1' t2' = t1 == t1' && t2 == t2'
+    SumTy  t1 t2 == SumTy  t1' t2' = t1 == t1' && t2 == t2'
+    FunTy  t1 t2 == FunTy  t1' t2' = t1 == t1' && t2 == t2'
+    TyVar t      == TyVar t'       = t == t'
+    RefTy t      == RefTy t'       = t == t'
+    TraceTy t    == TraceTy t'     = t == t'
+    _            == _              = False
+
+deriving instance Ord Type
 
 type Ctx = Env Type

--- a/lib/Language/Slicer/Monad/Desugar.hs
+++ b/lib/Language/Slicer/Monad/Desugar.hs
@@ -3,7 +3,6 @@
 module Language.Slicer.Monad.Desugar
     ( DesugarM, runDesugarM, getGamma, getDecls
     , withGamma, withBinder, maybeWithBinder
-    , pushExnType, popExnType
     ) where
 
 import qualified Language.Slicer.Absyn as A
@@ -47,17 +46,6 @@ getGamma = do
 -- | Get data declarations in scope
 getDecls :: DesugarM A.TyCtx
 getDecls = ask
-
-pushExnType :: Type -> DesugarM ()
-pushExnType ty = do
-  st@(DesugarState { exnType })<- get
-  when (exnType == Nothing) (put (st { exnType = Just ty }))
-
-popExnType :: DesugarM (Maybe Type)
-popExnType = do
-  st@(DesugarState { exnType }) <- get
-  put (st { exnType = Nothing })
-  return exnType
 
 getExnType :: DesugarM (Maybe Type)
 getExnType = do

--- a/lib/Language/Slicer/Parser.hs
+++ b/lib/Language/Slicer/Parser.hs
@@ -360,13 +360,11 @@ raise_ = keyword strRaise >> exp >>= return . Raise
 -- Try-with block
 tryWith_ :: Parser Exp
 tryWith_ = do
-  body    <- keyword strTry  >> exp
-  (x, ty) <- keyword strWith >> parenthesise (do x  <- var_
-                                                 ty <- typeAnnotation
-                                                 return (x, ty))
+  body <- keyword strTry  >> exp
+  x    <- keyword strWith >> var_
   reservedOp token_ strFunBodySep
   handler <- exp
-  return (Catch body x ty handler)
+  return (Catch body x handler)
 
 -- Comments.  See Note [Comments hack]
 comments :: Parser String

--- a/src/Language/Slicer/Monad/Repl.hs
+++ b/src/Language/Slicer/Monad/Repl.hs
@@ -6,10 +6,11 @@ module Language.Slicer.Monad.Repl
     ) where
 
 import           Language.Slicer.Absyn
-import qualified Language.Slicer.Core as C         ( Value, Type )
+import qualified Language.Slicer.Core as C         ( Value, Type              )
 import           Language.Slicer.Env
-import           Language.Slicer.Monad.Eval hiding ( addBinding  )
-import qualified Language.Slicer.Monad.Eval as E   ( addBinding  )
+import           Language.Slicer.Monad.Eval hiding ( addBinding, getEvalState
+                                                   , setEvalState             )
+import qualified Language.Slicer.Monad.Eval as E   ( addBinding               )
 
 import           Control.Monad.State.Strict
 

--- a/tests/SlicerTestSuite.hs
+++ b/tests/SlicerTestSuite.hs
@@ -16,6 +16,7 @@ tests =
       , runTMLTest "curried-pointwise-sum"
       , runTMLTest "curried-pointwise-sum-two"
       , runTMLTest "example"
+      , runTMLTest "exceptions"
       , runTMLTest "filter"
       , runTMLTest "foo"
       , runTMLTest "map-increment-closed"

--- a/tests/golden-templates/exceptions.golden
+++ b/tests/golden-templates/exceptions.golden
@@ -1,0 +1,2 @@
+Running ../../examples/exceptions.tml
+val it = 17 : int


### PR DESCRIPTION
I implemented support for exceptions. What works:

  * Throwing and catching exceptions

  * Nested exceptions:
    ```
    let n = ref 0 in
    try
      n:=17;;(raise (raise n));;n:=42;;(!n)
    with (x : ref int) => !x
    ```
    The innermost exception takes priority, so the above program is equivalent to:

    ```
    let n = ref 0 in
    try
      n:=17;;(raise n);;n:=42;;(!n)
    with (x : ref int) => !x
    ```

  * Type-checking of exceptions. If you say:

    ```
    let n = ref 0 in
    try
      (raise (if false then (raise true) else (raise 42))) ;; n:=1 ;; !n
    with (x : int) => !x
    ```
    this will be rejected because in the `with` block expression `x` inside exception is declared as `int` but in the `then` branch of `if` a `bool` is thrown.

  * Both the `try` and `with` blocks are required to have the same type.

What does not work:

  * exceptions inside `case` scrutinee are not supported. Doing this would require writing a type inference algorithm that figures out what type are we matching on without knowing the type of scrutinee.

  * Expressions inside uncaught exceptions are not pretty printed. So if I say:
    ```
    let n = ref 0 in
    raise n
    ```
    This is printed as `Uncaught exception: VStoreLoc 0` instead of something more sensible like `Uncaught exception: <ref>`. I can fix this if we think this is problematic. The reason I didn't do it is that it causes module cycles.

What needs attention:

  * typechecking got more complicated because `raise` can inhabit every type and so we now have an `ExnTy` that is equal to every other type. Everything seems to be implemented correctly but it is possible that I made a mistake somewhere.

  * Implementation of exception catching is tricky as it requires careful manipulation of scope and reference store. It seems to work correctly but yell if you any unexpected behaviours.

See Note [Evaluation of exceptions] for more details